### PR TITLE
Fix compilation problem when compile using Cygwin or Mingw

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,6 +11,9 @@ AM_YFLAGS = -d
 
 AM_CPPFLAGS = -I{srcdir}
 
+# '-no-undefined' should be specified when compile using Cygwin or Mingw
+AM_LDFLAGS = -no-undefined
+
 ## Enable debugging of linker script parser
 YYDEBUG = -DYYDEBUG=1
 


### PR DESCRIPTION
I met a compilation problem when compile using Cygwin or Mingw.
Libtool suggest that '-no-undefined' should be specified.

So, I wish this commit could be merged. Thanks for your great work.